### PR TITLE
Fixing issues #10, #11, #13, #14

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -93,7 +93,8 @@ class ExternalModule extends AbstractExternalModule {
 
         $fields = empty($_GET['page']) ? $Proj->metadata : $Proj->forms[$_GET['page']]['fields'];
         foreach (array_keys($fields) as $field_name) {
-            $misc = $Proj->metadata[$field_name]['misc'];
+            $field_info = $Proj->metadata[$field_name];
+            $misc = $field_info['misc'];
 
             // Getting available action tags.
             $action_tags = $this->getMultipleActionTagsQueue($action_tags_to_look, $misc);
@@ -122,9 +123,9 @@ class ExternalModule extends AbstractExternalModule {
                             break;
                         }
 
-                        if (!empty($data[$event]) && isset($data[$event][$source_field])) {
+                        if (in_array($field_info['form_name'], $Proj->eventsForms[$event])) {
                             // Getting previous event value.
-                            $default_value = $data[$event][$source_field];
+                            $default_value = isset($data[$event][$source_field]) ? $data[$event][$source_field] : '';
 
                             // Handling checkboxes case.
                             if (is_array($default_value)) {

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -125,6 +125,18 @@ class ExternalModule extends AbstractExternalModule {
                         if (!empty($data[$event]) && isset($data[$event][$source_field])) {
                             // Getting previous event value.
                             $default_value = $data[$event][$source_field];
+
+                            // Handling checkboxes case.
+                            if (is_array($default_value)) {
+                                $selected = array();
+                                foreach ($default_value as $option => $checked) {
+                                    if ($checked) {
+                                        $selected[] = $option;
+                                    }
+                                }
+
+                                $default_value = implode(',', $selected);
+                            }
                         }
                     }
                 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -107,7 +107,7 @@ class ExternalModule extends AbstractExternalModule {
             // action tags.
             foreach ($action_tags as $action_tag) {
                 if (strpos($action_tag, '@DEFAULT-FROM-PREVIOUS-EVENT') === 0) {
-                    if (!$source_field = Form::getValueInActionTag($misc, $action_tag)) {
+                    if (!$source_field = self::getValueInActionTag($misc, $action_tag)) {
                         // If no value is provided on the action tag, set the same
                         // field as source by default.
                         $source_field = $field_name;
@@ -116,6 +116,7 @@ class ExternalModule extends AbstractExternalModule {
                         // Invalid field.
                         continue;
                     }
+
                     foreach ($events as $event) {
                         if ($event == $_GET['event_id']) {
                             break;
@@ -314,5 +315,25 @@ class ExternalModule extends AbstractExternalModule {
      */
     protected function setJsSetting($key, $value) {
         echo '<script>autoPopulateFields = {' . $key . ': ' . json_encode($value) . '};</script>';
+    }
+
+    /**
+     * Alternative version of Form::getValueInActionTags.
+     *
+     * Fixes problems with single quoted values.
+     *
+     * @see Form::getValueInActionTags()
+     */
+    public static function getValueInActionTag($subject, $action_tag) {
+        if ($value = Form::getValueInQuotesActionTag($subject, $action_tag)) {
+            return $value;
+        }
+
+        preg_match('/' . $action_tag .'\s*=\s*([^\s]+)/', $subject, $matches);
+        if (empty($matches[1])) {
+            return '';
+        }
+
+        return $matches[1];
     }
 }

--- a/README.md
+++ b/README.md
@@ -18,16 +18,22 @@ By default, when a field that is hidden by branching logic contains a `@DEFAULT`
 This module changes the default branching logic behavior in order to avoid that. Now, when some non-empty field gets hidden by branching logic, no more warning messages are shown - instead, the hidden value persists available until form submission, when it is finally erased.
 
 ### Choice key piping on @DEFAULT
-When piping some choice selection field (dropdown, radio buttons) to set a @DEFAULT action tag, the returned value is now the key instead of the label.
+This module changes the display of selection fields when they are referenced in `@DEFAULT` action tags - instead of the label, the key is returned. Example: let's say we have a dropdown field called `animals`, whose options are:
+```
+1,Lion
+2,Monkey
+```
+If we define somewhere `@DEFAULT="[animals]"`, the returned value will be `1` (instead of "Lion") or `2` (instead of "Monkey").
+
 
 ### New action tags
 This module provides 2 new [action tags](https://wiki.chpc.utah.edu/pages/viewpage.action?pageId=595001400):
 
-#### @DEFAULT-FROM-PREVIOUS-EVENT
-Sets a field's default value based on its own value in a previous event. To map the default value from another field, you may specify the source field name as a parameter to the action tag, e.g `@DEFAULT-FROM-PREVIOUS-EVENT="source_field"`. Analogously to `@DEFAULT_<N>`, `@DEFAULT-FROM-PREVIOUS-EVENT_<N>` is also provided.
-
 #### @DEFAULT_\<N\>
 Provides the possibility to define secondary, tertiary, etc default values. If `@DEFAULT` returns an empty value, the next tag available - let's say `@DEFAULT_1` - is checked. If `@DEFAULT_1` returns empty, the next tag available - let's say `@DEFAULT_2` - is checked, and so on. This is useful when a fallback value is needed for piping (e.g. `@DEFAULT="[first_name]" @DEFAULT_1="Joe Doe"`).
+
+#### @DEFAULT-FROM-PREVIOUS-EVENT
+Sets a field's default value based on its own value in a previous event. To map the default value from another field, you may specify the source field name as a parameter to the action tag, e.g `@DEFAULT-FROM-PREVIOUS-EVENT="source_field"`. Analogously to `@DEFAULT_<N>`, `@DEFAULT-FROM-PREVIOUS-EVENT_<N>` is also provided.
 
 ### Mixing @DEFAULT_\<N\> and @DEFAULT-FROM-PREVIOUS-EVENT_\<N\>
 

--- a/js/default_when_visible.js
+++ b/js/default_when_visible.js
@@ -32,3 +32,28 @@ autoPopulateFields.defaultWhenVisible.init = function() {
 };
 
 autoPopulateFields.defaultWhenVisible.init();
+
+/**
+ * This block of code prevents "leave with unsaved changes" alerts from being
+ * supressed due to showEraseValuePrompt = 0.
+ */
+$(document).ready(function() {
+    var oldOnBeforeUnload = window.onbeforeunload;
+
+    window.onbeforeunload = function() {
+        // Enable flag when user is leaving the window.
+        showEraseValuePrompt = 1;
+        return oldOnBeforeUnload();
+    }
+
+    $('a').click(function(event) {
+        // Enable flag when user is leaving the window by clicking on a link.
+        showEraseValuePrompt = 1;
+    });
+
+    $('input, select').change(function() {
+        // Disabling flag when some value is changed to preserve
+        // "Default when visible" functionality.
+        showEraseValuePrompt = 0;
+    });
+});


### PR DESCRIPTION
Fixes issues:
- https://github.com/ctsit/auto_populate_fields/issues/10
- https://github.com/ctsit/auto_populate_fields/issues/11
- https://github.com/ctsit/auto_populate_fields/issues/13
- https://github.com/ctsit/auto_populate_fields/issues/14

Review steps (https://github.com/ctsit/auto_populate_fields/issues/10):
- [x] Open a non empty form
- [x] Make some change and try to leave form by closing the browser tab
- [x] Make sure you see a warning that prevents you to leave
- [x] Try to leave by clicking on some link
- [x] Make sure you see a warning that prevents you to leave
- [x] Make sure you do not see regressions on Default when visible functionality (see review steps [here](https://github.com/ctsit/auto_populate_fields/pull/9))

Review steps (https://github.com/ctsit/auto_populate_fields/issues/11)
- [x] Try several combinations of `@DEFAULT-FROM-PREVIOUS-EVENT_N` containing single quotes and no quotes and make sure action tag logic still works. Example:
```
@DEFAULT-FROM-PREVIOUS-EVENT_1='field_1'
@DEFAULT-FROM-PREVIOUS-EVENT_2=field_2
@DEFAULT-FROM-PREVIOUS-EVENT_3='field_3'
```

Review steps (https://github.com/ctsit/auto_populate_fields/issues/13):
- [x] Make sure that `@DEFAULT-FROM-PREVIOUS-EVENT` works with checkboxes

Review steps (https://github.com/ctsit/auto_populate_fields/issues/14):
- [x] Make sure Linear Data Entry Workflow is disabled
- [x] Choose a field to test that is present in more than 2 events
- [x] Add a `@DEFAULT-FROM-PREVIOUS-EVENT` to that field
- [x] Add a new entry, fill the first event (that contains that field), then jump to the 3rd one
- [x] Make sure that no default value is filled
- [x] Access the 2nd instrument (that contains that field) and make sure that now you see the default value
