### PR TITLE
Adding link to GitHub documentation on module description.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Auto Populate Fields",
     "namespace": "AutoPopulateFields\\ExternalModule",
-    "description": "This module provides rich control of default values for data entry fields via a set of action tags. These action tags allow fields to be populated based on values from an ordered list of fields and static values. The fields can be read from the current event or the previous event in longitudinal projects.",
+    "description": "This module provides rich control of default values for data entry fields via a set of action tags. These action tags allow fields to be populated based on values from an ordered list of fields and static values. The fields can be read from the current event or the previous event in longitudinal projects. <strong><a href=\"https://github.com/ctsit/auto_populate_fields\">See full documentation here</a></strong>.",
     "permissions": [
         "hook_every_page_top"
     ],


### PR DESCRIPTION
Review steps:
- [ ] Enable auto populate fields on Control Center and make sure you see the "see full documentation" link on module description
![screen shot 2017-12-21 at 4 15 29 pm](https://user-images.githubusercontent.com/29384017/34275256-819fc6e2-e66a-11e7-9656-057137665b2c.png)
- [ ] Click on link and make sure you get redirected to https://github.com/ctsit/auto_populate_fields
