### PR TITLE
document need for alter-table privileges

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -3,7 +3,6 @@
  * @file
  * Provides ExternalModule class for Auto Populate Fields.
  */
-
 namespace AutoPopulateFields\ExternalModule;
 
 use ExternalModules\AbstractExternalModule;
@@ -49,6 +48,7 @@ class ExternalModule extends AbstractExternalModule {
 
         // Indexing redcap_log_event's project_id column for performance
         // reasons.
+        // TODO: check user priviliges, send message reminding of requirements and disable if not able to alter db
         if (($q = $this->query($sql)) && !db_num_rows($q)) {
             $this->query('ALTER TABLE `redcap_log_event` ADD INDEX `project_id` (`project_id`)');
         }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This REDCap module provides rich control of default values for data entry fields
 - Go to **Control Center > Manage External Modules** and enable Auto Populate Fields.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Auto Populate Fields for that project.
 
+## Requirements
+This module **must** be _enabled_ by a user with alter-table privileges, it will fail to be enabled otherwise.
+
 ## Features included
 
 ### Default when visible


### PR DESCRIPTION
Addresses #19 

Adds documentation to the README. The module gives a fairly easily understood message on failure, ~~but checking user privileges and sending a gentler notice may be preferable.~~ which is sufficiently descriptive and disables the module, no need to reinvent the wheel.