### PR TITLE
add check for survey page

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -30,7 +30,7 @@ class ExternalModule extends AbstractExternalModule {
         if (PAGE == 'Design/online_designer.php') {
             $this->includeJs('js/helper.js');
         }
-        elseif (PAGE == 'DataEntry/index.php' && !empty($_GET['id'])) {
+        elseif ( (PAGE == 'DataEntry/index.php' || PAGE == 'surveys/index.php') && !empty($_GET['id'])) {
             if (!$this->currentFormHasData()) {
                 $this->setDefaultValues();
             }


### PR DESCRIPTION
Addresses issue #20 

Since [surveys are specifically mentioned in `currentFormHasData`](https://github.com/ctsit/auto_populate_fields/blob/b606071df19421d02a34732c980fba0ac5badff2/ExternalModule.php#L250), I think this was always meant to have been enabled on survey pages, surveys were just forgotten in the check.

May need some stress testing with events.