### PR TITLE
fix crashing on mismatched Date formats

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -238,7 +238,9 @@ class ExternalModule extends AbstractExternalModule {
                     }
                     if ($in_format !== 'ymd') {
                         $date = \DateTime::createFromFormat($in_format, $default_value);
-                        $default_value = $date->format($out_format);
+                        // This ternary prevents crashing for mixed source and target formats (e.g. YMD -> DMY)
+                        // users will get validation errors
+                        $default_value = ($date) ? $date->format($out_format) : $default_value;
                     }
                 }
 


### PR DESCRIPTION
Addresses #26 

Mismatched Date types was causing `$default_value` to be `false`, in turn rendering the `$date` object false, causing a crash when mixing `YMD`, `DMY`, and `MDY` date formats.


[APF_data_dictionary.zip](https://github.com/ctsit/auto_populate_fields/files/3865946/APF_data_dictionary.zip)
