### PR TITLE
remove setting project_id as an index in redcap_log_event table

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -41,27 +41,6 @@ class ExternalModule extends AbstractExternalModule {
     }
 
     /**
-     * @inheritdoc
-     */
-    function redcap_module_system_enable($version) {
-        $sql = 'SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE `table_schema` = DATABASE() AND `table_name` = "redcap_log_event" AND `index_name` = "project_id"';
-
-        // Indexing redcap_log_event's project_id column for performance
-        // reasons.
-        // TODO: check user priviliges, send message reminding of requirements and disable if not able to alter db
-        if (($q = $this->query($sql)) && !db_num_rows($q)) {
-            $this->query('ALTER TABLE `redcap_log_event` ADD INDEX `project_id` (`project_id`)');
-        }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    function redcap_module_system_version_change($version, $old_version) {
-        $this->redcap_module_system_enable($version);
-    }
-
-    /**
      * Extends @DEFAULT action tag.
      *
      * Features included:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ This REDCap module provides rich control of default values for data entry fields
 - Go to **Control Center > Manage External Modules** and enable Auto Populate Fields.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Auto Populate Fields for that project.
 
-## Requirements
-This module **must** be _enabled_ by a user with alter-table privileges, it will fail to be enabled otherwise.
-
 ## Features included
 
 ### Default when visible


### PR DESCRIPTION
Addresses issue #28 

Performance did not change in test cases when unsetting the INDEX status of `project_id`.

This also creates a new solution to #19 as the `ALTER TABLE` privilege of the activating user is no longer necessary; the corresponding lines in the README are deleted.