### PR TITLE
Address rc js version issues

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -26,6 +26,7 @@ class ExternalModule extends AbstractExternalModule {
             return;
         }
 
+        $this->initializeJsObject();
         if (PAGE == 'Design/online_designer.php') {
             $this->includeJs('js/helper.js');
         }
@@ -259,6 +260,9 @@ class ExternalModule extends AbstractExternalModule {
             list($equations[$field], ) = LogicTester::formatLogicToJS($equation, false, $_GET['event_id'], true);
         }
 
+        // More current versions of REDCap do not have all js libraries loaded in time
+        $this->setJsSetting('versionMod', version_compare(REDCAP_VERSION, '9.4.1', '>='));
+
         $this->setJsSetting('defaultWhenVisible', array('branchingEquations' => $equations));
         $this->includeJs('js/default_when_visible.js');
     }
@@ -400,7 +404,12 @@ class ExternalModule extends AbstractExternalModule {
      *   The setting value.
      */
     protected function setJsSetting($key, $value) {
-        echo '<script>autoPopulateFields = {' . $key . ': ' . json_encode($value) . '};</script>';
+        // initializeJsObject MUST be run once before this function
+        echo '<script>autoPopulateFields.' . $key . ' = ' . json_encode($value) . ';</script>';
+    }
+
+    protected function initializeJsObject() {
+        echo '<script>autoPopulateFields = {};</script>';
     }
 
     /**

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -90,7 +90,7 @@ class ExternalModule extends AbstractExternalModule {
                 // Getting chronological sequence of events.
                 $events = array();
 
-                $log_event_table = method_exists('\REDCap', 'getLogEventTable') ? \REDCap::getLogEventTable($project_id) : "redcap_log_event";
+                $log_event_table = method_exists('\REDCap', 'getLogEventTable') ? \REDCap::getLogEventTable($Proj->project_id) : "redcap_log_event";
 
                 $sql = '
                     SELECT MIN(log_event_id), event_id FROM ' . $log_event_table . '

--- a/js/default_when_visible.js
+++ b/js/default_when_visible.js
@@ -1,7 +1,4 @@
 autoPopulateFields.defaultWhenVisible.init = function() {
-    // Setting branching logic to do not show messages.
-    showEraseValuePrompt = 0;
-
     // Extracting evalLogic function body.
     var evalLogicBody = evalLogic.toString();
     var evalLogicBody = evalLogicBody.slice(evalLogicBody.indexOf('{') + 1, evalLogicBody.lastIndexOf('}'));
@@ -31,13 +28,23 @@ autoPopulateFields.defaultWhenVisible.init = function() {
     }
 };
 
-autoPopulateFields.defaultWhenVisible.init();
+// Setting branching logic to not show messages.
+showEraseValuePrompt = 0;
+
+// In REDCap >= 9.4.1 evalLogic is not always in scope immediately
+if (!autoPopulateFields.versionMod) {
+    autoPopulateFields.defaultWhenVisible.init();
+}
 
 /**
  * This block of code prevents "leave with unsaved changes" alerts from being
  * supressed due to showEraseValuePrompt = 0.
  */
 $(document).ready(function() {
+    if (autoPopulateFields.versionMod) {
+        autoPopulateFields.defaultWhenVisible.init(); // override evalLogic when it is in scope
+        doBranching(); // recalculate branching logic with the modified evalLogic
+    }
     var oldOnBeforeUnload = window.onbeforeunload;
 
     window.onbeforeunload = function() {


### PR DESCRIPTION
Addresses issue #32

REDCap 9.4.1 and greater moved the location of many JS functions into files separate from `base.js` causing their load order to change; this module operates by altering one of those functions in-place. This PR checks if the `REDCAP_VERSION` is affected and adjusts the overriding of said function accordingly.

To test, using at least two versions of REDCap (I have done 9.3.5, 9.4.1, and 9.4.2):
1. Create a new project from the template project under `examples/test_project.xml`
1. Activate APF on the project
1. Navigate to record 1
1. Enter the "Test branching logic" form under the "Visit 2" event
1. Click "Delete data for THIS FORM only"
1. Re-enter the "Test branching logic" form under the "Visit 2" event
1. Observe the following:
 - There is no error in the console regarding `evalLogic` not being loaded
 - There is no alert message
 -  The "Choice 2" text field does not appear initially<sup>1</sup>
 - Selecting "Yes" for "Show choice 2?" reveals auto-populated choice 2
 - Saving the form with any option other than "Yes" for "Show choice 2?" selected does **not** result in any entry being made for "Choice 2"


Additionally, properly implements the setJsSetting function to act as described:
https://github.com/ctsit/auto_populate_fields/blob/f04259580642360e38681af0e984cfcb6f742dd6/ExternalModule.php#L398
where previously an entirely new `autoPopulateFields` object was created every time the function was called.

___

<sup>1</sup> In REDCap versions greater than 9.4.1, the field may appear initially before disappearing because the override now must occur after the page has loaded. I tried checking if the `evalLogic` function was in scope and forcing its load before page load, but the async nature of JS and the call order meant more slowdown or simply no effect.