### PR TITLE
explicitly check that field to hide is present in a form

### DIFF
--- a/js/default_when_visible.js
+++ b/js/default_when_visible.js
@@ -33,7 +33,10 @@ autoPopulateFields.defaultWhenVisible.init = function() {
                 }
             }
             catch ( e ) {
-                evalLogicSubmit( fieldName, false, false );
+                // field specified in equation was not present
+                if ( document.getElementsByName(fieldName).length !== 0 ) { // must check if fieldName is present on multipage forms
+                    evalLogicSubmit( fieldName, false, false );
+                }
             }
         });
 


### PR DESCRIPTION
Fixes #48 

Now explicitly checks that a field is present before attempting to hide it.

To test:
1. Use a REDCap instance 10.0.11 or greater
1. Create any project which has a multi-page survey using an ICF Form
1. Enable Auto Populate Fields
1. Watch the console while filling out the survey
1. Observe that no errors appear upon clicking "Next Page"