### PR TITLE
Initialize eventsForms[$event] as an array if null

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -167,7 +167,9 @@ class ExternalModule extends AbstractExternalModule {
                         if ($event == $_GET['event_id']) {
                             break;
                         }
-
+                        // assign a data type to prevent PHP warning using null coalescing operator
+                        $Proj->eventsForms[$event] ??= [];
+                        
                         if (in_array($source_form, $Proj->eventsForms[$event])) {
                             $prev_event = $event;
                         }


### PR DESCRIPTION
This will prevent the error: Argument #2 ($haystack) must be of type array, null given. Addresses #61 